### PR TITLE
fix(backend): bump psycopg binary to 3.2.13

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,5 +1,5 @@
 fastapi==0.115.2
 uvicorn==0.30.6
 sqlalchemy==2.0.36
-psycopg[binary]==3.2.3
+psycopg[binary]==3.2.13
 pydantic==2.9.2


### PR DESCRIPTION
## Summary
- update backend dependency from `psycopg[binary]==3.2.3` to `psycopg[binary]==3.2.13`
- fix pip install failure: `No matching distribution found for psycopg-binary==3.2.3`

## Verification
- ✅ `pip install -r backend/requirements.txt` succeeds with Python 3.9.6
- ⚠️ `pytest -q` currently fails in this environment because DB host `192.168.50.245:5432` is unreachable (`No route to host`)