### PR TITLE
Contributor onboarding: dev setup + templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,41 @@
+name: Bug report
+description: Report a reproducible problem
+title: "bug: <short summary>"
+labels: ["bug"]
+body:
+  - type: textarea
+    id: what
+    attributes:
+      label: What happened?
+      description: A clear and concise description of the bug.
+      placeholder: "When I ..., Memrail ..."
+    validations:
+      required: true
+  - type: textarea
+    id: reproduce
+    attributes:
+      label: Steps to reproduce
+      description: Include minimal steps.
+      placeholder: |
+        1. ...
+        2. ...
+        3. ...
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behavior
+      placeholder: "I expected ..."
+    validations:
+      required: true
+  - type: input
+    id: version
+    attributes:
+      label: Commit / version
+      description: Git SHA or release tag if known.
+  - type: textarea
+    id: logs
+    attributes:
+      label: Logs / screenshots
+      description: Attach relevant logs or screenshots (use synthetic test data if possible).

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,5 +1,5 @@
-blank_issues_enabled: false
+blank_issues_enabled: true
 contact_links:
-  - name: Security report
+  - name: Security reports
     url: https://github.com/zhuamber370/memrail/security/policy
-    about: Please report vulnerabilities through the security policy.
+    about: Please report security vulnerabilities privately via SECURITY.md

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,28 @@
+name: Feature request
+description: Suggest an improvement
+title: "feat: <short summary>"
+labels: ["enhancement"]
+body:
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem
+      description: What problem are you trying to solve?
+    validations:
+      required: true
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposal
+      description: What would you like to happen?
+    validations:
+      required: true
+  - type: textarea
+    id: scope
+    attributes:
+      label: Scope / acceptance criteria
+      description: Define the minimum viable version and how we can verify it.
+      placeholder: |
+        - MVP:
+        - Out of scope:
+        - Acceptance:

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,29 @@
+## Summary
+
+What does this PR change, and why?
+
+## Type
+
+- [ ] Bug fix
+- [ ] Feature
+- [ ] Docs
+- [ ] Refactor
+- [ ] Chore
+
+## Verification
+
+Commands you ran and results (paste output if useful):
+
+- Backend:
+  - `cd backend && python3 -m pytest -q`
+- Frontend:
+  - `cd frontend && npm run build`
+
+## Screenshots (UI changes)
+
+Attach before/after screenshots if this changes UI.
+
+## Notes
+
+- If behavior changed, update README/docs.
+- Do not include secrets in commits.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,22 +1,45 @@
 # Contributing
 
-Thanks for contributing to `memrail`.
+Thanks for contributing to **Memrail**.
+
+Memrail is an OpenClaw workflow command center where **agent proposals are governed by human review** (with audit + undo). Contributions that improve reliability, clarity, and contributor experience are especially welcome.
+
+## Quick start for contributors
+
+1) Read the dev setup guide: `docs/contributing/dev-setup.md`
+
+2) Run the stack locally:
+- Backend: `backend/README.md`
+- Frontend: `frontend/README.md`
+
+3) Pick a task:
+- Look for issues labeled **good first issue** / **help wanted**.
+- If you're not sure where to start, open an issue with your background (backend/frontend/full-stack) and we’ll point you to a small, high-signal change.
+
+## Where help is most valuable (early stage)
+
+- **Governed write pipeline**: dry-run → commit/reject → undo-last
+- **Changes review UX** (`/changes`): diff readability, safety checks, undo clarity
+- **Tasks route graph** (`/tasks`): node/edge operations, status, inspector UX
+- **Knowledge workspace** (`/knowledge`): CRUD, filters, category/status lifecycle
+- **Docs**: API surface accuracy, onboarding guides, screenshots using synthetic test data
 
 ## Before opening a PR
 
-1. Open an issue first for non-trivial changes.
-2. Keep diffs small and focused.
-3. Do not include secrets (`.env`, tokens, private keys).
-4. Keep behavior docs in sync with code.
-5. If tests insert data, clean test data before merge.
+- For non-trivial changes: open an issue first to align on scope.
+- Keep diffs small and focused.
+- Do not include secrets (`.env`, tokens, private keys).
+- Keep runtime docs in sync with code (README/docs).
+- If tests insert data, clean test data before merge.
 
 ## Local checks
 
 ### Backend
 
 ```bash
+cd backend
 python3 -m pytest -q
-python3 backend/scripts/cleanup_test_data.py
+python3 scripts/cleanup_test_data.py
 ```
 
 ### Frontend
@@ -28,7 +51,8 @@ npm run build
 
 ## PR expectations
 
-1. Explain what changed and why.
-2. List verification commands and actual results.
-3. Include screenshots for UI changes.
-4. Mention updated docs when behavior changed.
+Please include:
+- What changed + why
+- How you verified (commands + results)
+- Screenshots for UI changes
+- Any doc updates (if behavior changed)

--- a/README.md
+++ b/README.md
@@ -145,6 +145,10 @@ openclaw skills info kms --json
 openclaw skills check --json
 ```
 
+## Contributing
+
+Contributions are welcome! See `CONTRIBUTING.md` and `docs/contributing/dev-setup.md`.
+
 ## Documentation Map
 
 Authoritative runtime docs:

--- a/docs/contributing/dev-setup.md
+++ b/docs/contributing/dev-setup.md
@@ -1,0 +1,90 @@
+# Dev Setup (Contributors)
+
+This guide is optimized for getting a new contributor to a working local environment quickly.
+
+## Prerequisites
+
+- Python 3.10+
+- Node.js 18+
+
+## Repo layout
+
+- `backend/` — FastAPI + SQLAlchemy
+- `frontend/` — Next.js 14
+- `docs/` — documentation
+
+## 1) Clone
+
+```bash
+git clone https://github.com/zhuamber370/memrail.git
+cd memrail
+```
+
+## 2) Configure env
+
+```bash
+cp .env.example .env
+cp .env frontend/.env.local
+```
+
+Notes:
+- Backend reads `backend/.env` and root `.env`.
+- Frontend reads `frontend/.env.local`.
+
+## 3) Run backend
+
+See: `backend/README.md`
+
+Typical local run:
+
+```bash
+cd backend
+python3 -m venv .venv
+source .venv/bin/activate
+pip install -r requirements.txt
+python3 -m uvicorn src.app:app --reload --port 8000
+```
+
+Verify:
+- http://127.0.0.1:8000/health
+
+## 4) Run frontend
+
+See: `frontend/README.md`
+
+```bash
+cd frontend
+npm install
+npm run dev
+```
+
+Verify:
+- http://127.0.0.1:3000
+
+## 5) Running tests
+
+Backend:
+
+```bash
+cd backend
+python3 -m pytest -q
+python3 scripts/cleanup_test_data.py
+```
+
+Frontend:
+
+```bash
+cd frontend
+npm run build
+```
+
+## What to contribute first
+
+Good first contributions (high-signal, low-risk):
+- Documentation fixes (API surface sync, README clarity)
+- Small UI copy improvements (keep tone factual)
+- UX polish on `/changes` diff readability
+
+If you’re unsure, open an issue with:
+- Your preferred area (backend/frontend/full-stack/docs)
+- Your available time (e.g. 30–60 min / weekend)


### PR DESCRIPTION
This PR improves the contributor experience (full-stack friendly):

- Add contributor dev setup guide: `docs/contributing/dev-setup.md`
- Upgrade `CONTRIBUTING.md` with onboarding + high-value contribution areas
- Add PR template: `.github/PULL_REQUEST_TEMPLATE.md`
- Add issue templates (bug + feature): `.github/ISSUE_TEMPLATE/*`

Why:
- Reduce time-to-first-contribution
- Standardize verification info in PRs
- Improve issue quality and triage

Notes:
- No production code changes.
- Screenshots/docs should use synthetic test data.
