### PR TITLE
Docs: add maintainer support note for new contributors

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,6 +6,8 @@ Memrail is an OpenClaw workflow command center where **agent proposals are gover
 
 ## Quick start for contributors
 
+If you want to contribute but feel blocked, comment on the relevant issue — maintainers can point you to the best starting files / components.
+
 1) Read the dev setup guide: `docs/contributing/dev-setup.md`
 
 2) Run the stack locally:

--- a/README.md
+++ b/README.md
@@ -149,6 +149,8 @@ openclaw skills check --json
 
 Contributions are welcome! See `CONTRIBUTING.md` and `docs/contributing/dev-setup.md`.
 
+If you want to contribute but are unsure where to start, open an issue (or comment on an existing one) and maintainers can point you to a small, high-signal first change.
+
 ## Documentation Map
 
 Authoritative runtime docs:


### PR DESCRIPTION
Adds a short note in README + CONTRIBUTING to encourage new contributors to comment on issues when blocked, so maintainers can point them to the right files/components.

Why:
- Reduces hesitation to pick up good first issues
- Improves time-to-first-contribution

Scope:
- Docs only (no code changes)
