### PR TITLE
Docs: move kms how-to-ask section into the intro

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,27 @@ Memrail keeps your workflow **executable, governed, and traceable**.
 - One-screen workspace: /tasks + /knowledge + /changes
 - Audit trail for every proposal and commit
 
+## How to ask (OpenClaw kms skill)
+
+Memrail ships with an OpenClaw skill (`kms`) that routes **natural-language requests** to governed reads/writes.
+
+- **Reads are safe by default**.
+- **Writes require explicit intent** and follow: **dry-run → confirm → commit**.
+
+**Read (no writes)**
+- "What is the current progress of task 'Agent-first SaaS'? What's the current node and its status?"
+- "Show me the route graph for task 'Agent-first SaaS' and the next steps on the critical path."
+- "Search knowledge for 'governed proposals' and summarize the top 3 results."
+
+**Write (will propose a change first)**
+- "Record this TODO in Memrail: 'Add README how-to-ask examples', priority P1, topic 'Memrail'."
+- "Create a knowledge note (decision_record): title 'Memrail positioning v0', body: ..."
+
+**Confirm / reject / undo**
+- "Confirm and commit the proposal."
+- "Reject the proposal."
+- "Undo the last commit."
+
 ## Screenshots
 > Screenshots use **synthetic test data**.
 
@@ -147,29 +168,7 @@ openclaw skills check --json
 
 ### How to ask (examples)
 
-The `kms` skill routes **natural-language requests** to Memrail reads/writes.
-
-- **Reads are safe by default**.
-- **Writes require an explicit write intent**, and follow: **dry-run → confirm → commit**.
-
-#### Read examples (no writes)
-
-- "What is the current progress of task 'Agent-first SaaS'? What's the current node and its status?"
-- "Show me the route graph for task 'Agent-first SaaS' and the next steps on the critical path."
-- "List the most recently updated knowledge items (active)."
-- "Search knowledge for 'governed proposals' and summarize the top 3 results."
-
-#### Write examples (will propose a change first)
-
-- "Record this TODO in Memrail: 'Add README how-to-ask examples', priority P1, topic 'Memrail'."
-- "Create a knowledge note (decision_record): title 'Memrail positioning v0', body: ..."
-- "Create a route under task 'Agent-first SaaS': Start → Plan → Implement → Review → Done."
-
-#### Confirm / reject / undo
-
-- "Confirm and commit the proposal."
-- "Reject the proposal." 
-- "Undo the last commit."
+See **How to ask (OpenClaw kms skill)** near the top of this README.
 
 ## Contributing
 


### PR DESCRIPTION
Moves the "How to ask (OpenClaw kms skill)" guidance closer to the top of README (right after the value proposition), so users see how to interact with Memrail via OpenClaw early.

Also replaces the previous copy under the OpenClaw Skill section with a pointer to the intro section to avoid duplication.

Scope:
- Docs only
